### PR TITLE
Feat/memory allocator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ target
 wasabi/mnt/
 wasabi/target/
 wasabi/third_party/ovmf/*
+wasabi/log/*
 
 # UEFI variables (runtime state)
 **/NvVars

--- a/wasabi/scripts/launch_qemu.sh
+++ b/wasabi/scripts/launch_qemu.sh
@@ -7,10 +7,13 @@ rm -rf mnt
 mkdir -p mnt/EFI/BOOT/
 cp ${PATH_TO_EFI} mnt/EFI/BOOT/BOOTX64.EFI
 set +e
+mkdir -p log
 qemu-system-x86_64 \
   -m 4G\
   -bios third_party/ovmf/RELEASEX64_OVMF.fd \
   -drive format=raw,file=fat:rw:mnt \
+  -chardev stdio,id=char_com1,mux=on,logfile=log/com1.txt \
+  -serial chardev:char_com1 \
   -device isa-debug-exit,iobase=0xf4,iosize=0x01
 RETCODE=$?
 set -e

--- a/wasabi/src/allocator.rs
+++ b/wasabi/src/allocator.rs
@@ -22,7 +22,17 @@ pub fn round_up_to_nearest_pow2(v: usize) -> Result<usize> {
 }
 #[test_case]
 fn round_up_to_nearest_pow2_tests() {
-    // unimplemented!("cargo test should fail, right...?")
+    assert_eq!(round_up_to_nearest_pow2(0), Err("Out of range"));
+    assert_eq!(round_up_to_nearest_pow2(1), Ok(1));
+    assert_eq!(round_up_to_nearest_pow2(2), Ok(2));
+    assert_eq!(round_up_to_nearest_pow2(3), Ok(4));
+    assert_eq!(round_up_to_nearest_pow2(4), Ok(4));
+    assert_eq!(round_up_to_nearest_pow2(5), Ok(8));
+    assert_eq!(round_up_to_nearest_pow2(6), Ok(8));
+    assert_eq!(round_up_to_nearest_pow2(7), Ok(8));
+    assert_eq!(round_up_to_nearest_pow2(8), Ok(8));
+    assert_eq!(round_up_to_nearest_pow2(9), Ok(16));
+    assert_eq!(round_up_to_nearest_pow2(9), Ok(16));
 }
 
 /// Vertical bar `|` represents the chunk that has a Header
@@ -183,7 +193,7 @@ impl FirstFitAllocator {
             }
             self.add_free_from_descriptor(e);
         }
-    }
+  }
     fn add_free_from_descriptor(&self, desc: &EfiMemoryDescriptor) {
         let mut start_addr = desc.physical_start() as usize;
         let mut size = desc.number_of_pages() as usize * 4096;

--- a/wasabi/src/allocator.rs
+++ b/wasabi/src/allocator.rs
@@ -16,6 +16,7 @@ use core::ops::DerefMut;
 use core::ptr::null_mut;
 
 pub fn round_up_to_nearest_pow2(v: usize) -> Result<usize> {
+    // Determine the exponent of the required power of 2 from the leading_zeros of v-1
     1usize
         .checked_shl(usize::BITS - v.wrapping_sub(1).leading_zeros())
         .ok_or("Out of range")
@@ -101,6 +102,7 @@ impl Header {
 
             // Make a Header for the allocated object
             let mut size_used = 0;
+            // By allocating from the rear, maintain a large contiguous area at the front
             let allocated_addr = (self.end_addr() - size) & !(align - 1);
             let mut header_for_allocated =
                 unsafe { Self::new_from_addr(allocated_addr - HEADER_SIZE) };
@@ -170,7 +172,7 @@ unsafe impl GlobalAlloc for FirstFitAllocator {
 impl FirstFitAllocator {
     pub fn alloc_with_options(&self, layout: Layout) -> *mut u8 {
         let mut header = self.first_header.borrow_mut();
-        let mut header = header.deref_mut();
+        let mut header = header.deref_mut();  // RefMut → &mut
         loop {
             match header {
                 Some(e) => match e.provide(layout.size(), layout.align()) {

--- a/wasabi/src/allocator.rs
+++ b/wasabi/src/allocator.rs
@@ -1,0 +1,206 @@
+extern crate alloc;
+
+use crate::result::Result;
+use crate::uefi::EfiMemoryDescriptor;
+use crate::uefi::EfiMemoryType;
+use crate::uefi::MemoryMapHolder;
+use alloc::alloc::GlobalAlloc;
+use alloc::alloc::Layout;
+use alloc::boxed::Box;
+use core::borrow::BorrowMut;
+use core::cell::RefCell;
+use core::cmp::max;
+use core::fmt;
+use core::mem::size_of;
+use core::ops::DerefMut;
+use core::ptr::null_mut;
+
+pub fn round_up_to_nearest_pow2(v: usize) -> Result<usize> {
+    1usize
+        .checked_shl(usize::BITS - v.wrapping_sub(1).leading_zeros())
+        .ok_or("Out of range")
+}
+
+/// Vertical bar `|` represents the chunk that has a Header
+/// before: |-- prev -------|---- self ---------------
+/// align:  |--------|-------|-------|-------|-------|
+/// after:  |---------------||-------|----------------
+
+struct Header {
+    next_header: Option<Box<Header>>,
+    size: usize,
+    is_allocated: bool,
+    _reserved: usize,
+}
+const HEADER_SIZE: usize = size_of::<Header>();
+#[allow(clippy::assertions_on_constants)]
+const _: () = assert!(HEADER_SIZE == 32);
+// Size of Header should be power of 2
+const _: () = assert!(HEADER_SIZE.count_ones() == 1);
+pub const LAYOUT_PAGE_4K: Layout = unsafe { Layout::from_size_align_unchecked(4096, 4096) };
+impl Header {
+    fn can_provide(&self, size: usize, align: usize) -> bool {
+        // This check is rough - actual size needed may be smaller.
+        // HEADER_SIZE * 2 => one for allocated region, another for padding.
+        self.size >= size + HEADER_SIZE * 2 * align
+    }
+    fn is_allocated(&self) -> bool {
+        self.is_allocated
+    }
+    fn end_addr(&self) -> usize {
+        self as *const Header as usize + self.size
+    }
+    unsafe fn new_from_addr(addr: usize) -> Box<Header> {
+        let header = addr as *mut Header;
+        header.write(Header {
+            next_header: None,
+            size: 0,
+            is_allocated: false,
+            _reserved: 0,
+        });
+        Box::from_raw(addr as *mut Header)
+    }
+    unsafe fn from_allocated_region(addr: *mut u8) -> Box<Header> {
+        let header = addr.sub(HEADER_SIZE) as *mut Header;
+        Box::from_raw(header)
+    }
+    //
+    // Note: std::alloc::Layout doc says:
+    // > All layouts have an associated size and a power-of-two alignment.
+    fn provide(&mut self, size: usize, align: usize) -> Option<*mut u8> {
+        let size = max(round_up_to_nearest_pow2(size).ok()?, HEADER_SIZE);
+        let align = max(align, HEADER_SIZE);
+        if self.is_allocated() || !self.can_provide(size, align) {
+            None
+        } else {
+            // Each char represents 32-byte-chunks.
+            //
+            // |-----|----------------- self ---------|----------
+            // |-----|----------------------          |----------
+            //                                        ^ self.end_addr()
+            //                              |-------|-
+            //                               ^ allocated_addr
+            //                              ^ header_for_allocated
+            //                                      ^ header_for_padding
+            //                                      ^ header_for_allocated.end_addr()
+            // self has enough space to allocate the requested object.
+
+            // Make a Header for the allocated object
+            let mut size_used = 0;
+            let allocated_addr = (self.end_addr() - size) & !(align - 1);
+            let mut header_for_allocated =
+                unsafe { Self::new_from_addr(allocated_addr - HEADER_SIZE) };
+            header_for_allocated.is_allocated = true;
+            header_for_allocated.size = size + HEADER_SIZE;
+            size_used += header_for_allocated.size;
+            header_for_allocated.next_header = self.next_header.take();
+            if header_for_allocated.end_addr() != self.end_addr() {
+                // Make a Header for padding
+                let mut header_for_padding =
+                    unsafe { Self::new_from_addr(header_for_allocated.end_addr()) };
+                header_for_padding.is_allocated = false;
+                header_for_padding.size = self.end_addr() - header_for_allocated.end_addr();
+                size_used += header_for_padding.size;
+                header_for_padding.next_header = header_for_allocated.next_header.take();
+                header_for_allocated.next_header = Some(header_for_padding);
+            }
+            // Shrink self
+            assert!(self.size >= size_used + HEADER_SIZE);
+            self.size -= size_used;
+            self.next_header = Some(header_for_allocated);
+            Some(allocated_addr as *mut u8)
+        }
+    }
+}
+impl Drop for Header {
+    fn drop(&mut self) {
+        panic!("Header should not be dropped!");
+    }
+}
+impl fmt::Debug for Header {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Header @ {:#018X} {{ size: {:#18X}, is_allocated: {} }}",
+            self as *const Header as usize,
+            self.size,
+            self.is_allocated()
+        )
+    }
+}
+
+pub struct FirstFitAllocator {
+    first_header: RefCell<Option<Box<Header>>>,
+}
+
+#[global_allocator]
+pub static ALLOCATOR: FirstFitAllocator = FirstFitAllocator {
+    first_header: RefCell::new(None),
+};
+
+// it's only temporary
+unsafe impl Sync for FirstFitAllocator {}
+
+unsafe impl GlobalAlloc for FirstFitAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        self.alloc_with_options(layout)
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        let mut region = Header::from_allocated_region(ptr);
+        region.is_allocated = false;
+        Box::leak(region);
+        // region is leaked here to avoid dropping the free info on the memory
+    }
+}
+
+impl FirstFitAllocator {
+    pub fn alloc_with_options(&self, layout: Layout) -> *mut u8 {
+        let mut header = self.first_header.borrow_mut();
+        let mut header = header.deref_mut();
+        loop {
+            match header {
+                Some(e) => match e.provide(layout.size(), layout.align()) {
+                    Some(p) => break p,
+                    None => {
+                        header = e.next_header.borrow_mut();
+                        continue;
+                    }
+                },
+                None => {
+                    break null_mut::<u8>();
+                }
+            }
+        }
+    }
+    pub fn init_with_mmap(&self, memory_map: &MemoryMapHolder) {
+        for e in memory_map.iter() {
+            if e.memory_type() != EfiMemoryType::CONVENTIONAL_MEMORY {
+                continue;
+            }
+            self.add_free_from_descriptor(e);
+        }
+    }
+    fn add_free_from_descriptor(&self, desc: &EfiMemoryDescriptor) {
+        let mut start_addr = desc.physical_start() as usize;
+        let mut size = desc.number_of_pages() as usize * 4096;
+        // Make sure the allocator does not include the address 0 as a free area.
+        if start_addr == 0 {
+            start_addr += 4096;
+            size = size.saturating_sub(4096);
+        }
+        if size <= 4096 {
+            return;
+        }
+        let mut header = unsafe { Header::new_from_addr(start_addr) };
+        header.next_header = None;
+        header.size = size;
+        let mut first_header = self.first_header.borrow_mut();
+        let prev_last = first_header.replace(header);
+        drop(first_header);
+        let mut header = self.first_header.borrow_mut();
+        header.as_mut().unwrap().next_header = prev_last;
+        // It's okay not to be sorted the headers at this point
+        // since all the regions written in memory maps are not contiguous
+        // so that they can't be merged anyway
+    }
+}

--- a/wasabi/src/allocator.rs
+++ b/wasabi/src/allocator.rs
@@ -22,7 +22,7 @@ pub fn round_up_to_nearest_pow2(v: usize) -> Result<usize> {
 }
 #[test_case]
 fn round_up_to_nearest_pow2_tests() {
-    unimplemented!("cargo test should fail, right...?")
+    // unimplemented!("cargo test should fail, right...?")
 }
 
 /// Vertical bar `|` represents the chunk that has a Header

--- a/wasabi/src/allocator.rs
+++ b/wasabi/src/allocator.rs
@@ -193,7 +193,7 @@ impl FirstFitAllocator {
             }
             self.add_free_from_descriptor(e);
         }
-  }
+    }
     fn add_free_from_descriptor(&self, desc: &EfiMemoryDescriptor) {
         let mut start_addr = desc.physical_start() as usize;
         let mut size = desc.number_of_pages() as usize * 4096;
@@ -216,5 +216,135 @@ impl FirstFitAllocator {
         // It's okay not to be sorted the headers at this point
         // since all the regions written in memory maps are not contiguous
         // so that they can't be merged anyway
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use alloc::vec;
+
+    #[test_case]
+    fn malloc_iterate_free_and_alloc() {
+        use alloc::vec::Vec;
+        for i in 0..1000 {
+            let mut vec = Vec::new();
+            vec.resize(i, 10);
+            // vec will be deallocated at the end of this scope
+        }
+    }
+
+    #[test_case]
+    fn malloc_align() {
+        let mut pointers = [null_mut::<u8>(); 100];
+        for align in [1, 2, 4, 8, 16, 32, 4096] {
+            for e in pointers.iter_mut() {
+                *e = ALLOCATOR.alloc_with_options(
+                    Layout::from_size_align(1234, align).expect("Failed to create Layout"),
+                );
+                assert!(*e as usize != 0);
+                assert!((*e as usize) % align == 0);
+            }
+        }
+    }
+
+    #[test_case]
+    fn malloc_align_random_order() {
+        for align in [32, 4096, 8, 4, 16, 2, 1] {
+            let mut pointers = [null_mut::<u8>(); 100];
+            for e in pointers.iter_mut() {
+                *e = ALLOCATOR.alloc_with_options(
+                    Layout::from_size_align(1234, align).expect("Failed to create Layout"),
+                );
+                assert!(*e as usize != 0);
+                assert!((*e as usize) % align == 0);
+            }
+        }
+    }
+
+    #[test_case]
+    fn allocated_objects_no_overlap() {
+        let allocations = [
+            Layout::from_size_align(128, 128).unwrap(),
+            Layout::from_size_align(32, 32).unwrap(),
+            Layout::from_size_align(8, 8).unwrap(),
+            Layout::from_size_align(16, 16).unwrap(),
+            Layout::from_size_align(6000, 64).unwrap(),
+            Layout::from_size_align(4, 4).unwrap(),
+            Layout::from_size_align(2, 2).unwrap(),
+            Layout::from_size_align(600000, 64).unwrap(),
+            Layout::from_size_align(64, 64).unwrap(),
+            Layout::from_size_align(1, 1).unwrap(),
+            Layout::from_size_align(6000, 64).unwrap(),
+            Layout::from_size_align(6000, 64).unwrap(),
+            Layout::from_size_align(6000, 64).unwrap(),
+            Layout::from_size_align(6000, 64).unwrap(),
+            Layout::from_size_align(6000, 64).unwrap(),
+            Layout::from_size_align(6000, 64).unwrap(),
+            Layout::from_size_align(3, 64).unwrap(),
+            Layout::from_size_align(3, 64).unwrap(),
+            Layout::from_size_align(3, 64).unwrap(),
+            Layout::from_size_align(3, 64).unwrap(),
+            Layout::from_size_align(3, 64).unwrap(),
+            Layout::from_size_align(3, 64).unwrap(),
+            Layout::from_size_align(3, 64).unwrap(),
+            Layout::from_size_align(3, 64).unwrap(),
+            Layout::from_size_align(3, 64).unwrap(),
+            Layout::from_size_align(3, 64).unwrap(),
+            Layout::from_size_align(6000, 64).unwrap(),
+            Layout::from_size_align(6000, 64).unwrap(),
+            Layout::from_size_align(600000, 64).unwrap(),
+            Layout::from_size_align(6000, 64).unwrap(),
+            Layout::from_size_align(60000, 64).unwrap(),
+            Layout::from_size_align(60000, 64).unwrap(),
+            Layout::from_size_align(60000, 64).unwrap(),
+            Layout::from_size_align(60000, 64).unwrap(),
+        ];
+        let mut pointers = vec![null_mut::<u8>(); allocations.len()];
+        for e in allocations.iter().zip(pointers.iter_mut()).enumerate() {
+            let (i, (layout, pointer)) = e;
+            *pointer = ALLOCATOR.alloc_with_options(*layout);
+            for k in 0..layout.size() {
+                unsafe { *pointer.add(k) = i as u8 }
+            }
+        }
+        for e in allocations.iter().zip(pointers.iter_mut()).enumerate() {
+            let (i, (layout, pointer)) = e;
+            for k in 0..layout.size() {
+                assert!(unsafe { *pointer.add(k) } == i as u8);
+            }
+        }
+        for e in allocations
+            .iter()
+            .zip(pointers.iter_mut())
+            .enumerate()
+            .step_by(2)
+        {
+            let (_, (layout, pointer)) = e;
+            unsafe { ALLOCATOR.dealloc(*pointer, *layout) }
+        }
+        for e in allocations
+            .iter()
+            .zip(pointers.iter_mut())
+            .enumerate()
+            .skip(1)
+            .step_by(2)
+        {
+            let (i, (layout, pointer)) = e;
+            for k in 0..layout.size() {
+                assert!(unsafe { *pointer.add(k) } == i as u8);
+            }
+        }
+        for e in allocations
+            .iter()
+            .zip(pointers.iter_mut())
+            .enumerate()
+            .step_by(2)
+        {
+            let (i, (layout, pointer)) = e;
+            for k in 0..layout.size() {
+                assert!(unsafe { *pointer.add(k) } == i as u8);
+            }
+        }
     }
 }

--- a/wasabi/src/allocator.rs
+++ b/wasabi/src/allocator.rs
@@ -20,6 +20,10 @@ pub fn round_up_to_nearest_pow2(v: usize) -> Result<usize> {
         .checked_shl(usize::BITS - v.wrapping_sub(1).leading_zeros())
         .ok_or("Out of range")
 }
+#[test_case]
+fn round_up_to_nearest_pow2_tests() {
+    unimplemented!("cargo test should fail, right...?")
+}
 
 /// Vertical bar `|` represents the chunk that has a Header
 /// before: |-- prev -------|---- self ---------------

--- a/wasabi/src/init.rs
+++ b/wasabi/src/init.rs
@@ -1,0 +1,15 @@
+use crate::allocator::ALLOCATOR;
+use crate::uefi::exit_from_efi_boot_services;
+use crate::uefi::EfiHandle;
+use crate::uefi::EfiSystemTable;
+use crate::uefi::MemoryMapHolder;
+
+pub fn init_basic_runtime(
+    image_handle: EfiHandle,
+    efi_system_table: &EfiSystemTable,
+) -> MemoryMapHolder {
+    let mut memory_map = MemoryMapHolder::new();
+    exit_from_efi_boot_services(image_handle, efi_system_table, &mut memory_map);
+    ALLOCATOR.init_with_mmap(&memory_map);
+    memory_map
+}

--- a/wasabi/src/lib.rs
+++ b/wasabi/src/lib.rs
@@ -8,6 +8,7 @@ pub mod allocator;
 pub mod graphics;
 pub mod qemu;
 pub mod result;
+pub mod serial;
 pub mod uefi;
 pub mod x86;
 

--- a/wasabi/src/lib.rs
+++ b/wasabi/src/lib.rs
@@ -4,6 +4,7 @@
 #![test_runner(crate::test_runner::test_runner)]
 #![reexport_test_harness_main = "run_unit_tests"]
 #![no_main]
+pub mod allocator;
 pub mod graphics;
 pub mod qemu;
 pub mod result;

--- a/wasabi/src/lib.rs
+++ b/wasabi/src/lib.rs
@@ -17,6 +17,10 @@ pub mod test_runner;
 
 #[cfg(test)]
 #[no_mangle]
-pub fn efi_main() {
+pub fn efi_main(image_handle: uefi::EfiHandle, efi_system_table: &uefi::EfiSystemTable) {
+    let mut memory_map = uefi::MemoryMapHolder::new();
+    uefi::exit_from_efi_boot_services(image_handle, efi_system_table, &mut memory_map);
+
+    allocator::ALLOCATOR.init_with_mmap(&memory_map);
     run_unit_tests()
 }

--- a/wasabi/src/lib.rs
+++ b/wasabi/src/lib.rs
@@ -6,6 +6,7 @@
 #![no_main]
 pub mod allocator;
 pub mod graphics;
+pub mod init;
 pub mod qemu;
 pub mod result;
 pub mod serial;
@@ -18,9 +19,6 @@ pub mod test_runner;
 #[cfg(test)]
 #[no_mangle]
 pub fn efi_main(image_handle: uefi::EfiHandle, efi_system_table: &uefi::EfiSystemTable) {
-    let mut memory_map = uefi::MemoryMapHolder::new();
-    uefi::exit_from_efi_boot_services(image_handle, efi_system_table, &mut memory_map);
-
-    allocator::ALLOCATOR.init_with_mmap(&memory_map);
+    init::init_basic_runtime(image_handle, efi_system_table);
     run_unit_tests()
 }

--- a/wasabi/src/main.rs
+++ b/wasabi/src/main.rs
@@ -10,6 +10,7 @@ use wasabi::graphics::fill_rect;
 use wasabi::graphics::Bitmap;
 use wasabi::qemu::exit_qemu;
 use wasabi::qemu::QemuExitCode;
+use wasabi::serial::SerialPort;
 use wasabi::uefi::exit_from_efi_boot_services;
 use wasabi::uefi::init_vram;
 use wasabi::uefi::EfiHandle;
@@ -22,6 +23,8 @@ use wasabi::x86::hlt;
 
 #[no_mangle] // Necessary to accurately maintain the name expected by external systems
 fn efi_main(image_handle: EfiHandle, efi_system_table: &EfiSystemTable) {
+    let mut sw = SerialPort::new_for_com1();
+    writeln!(sw, "Hello via serial port").unwrap();
     let mut vram = init_vram(efi_system_table).expect("init_vram failed");
     let vw = vram.width();
     let vh = vram.height();

--- a/wasabi/src/main.rs
+++ b/wasabi/src/main.rs
@@ -10,7 +10,6 @@ use wasabi::graphics::fill_rect;
 use wasabi::graphics::Bitmap;
 use wasabi::qemu::exit_qemu;
 use wasabi::qemu::QemuExitCode;
-use wasabi::serial::SerialPort;
 use wasabi::uefi::exit_from_efi_boot_services;
 use wasabi::uefi::init_vram;
 use wasabi::uefi::EfiHandle;
@@ -23,8 +22,6 @@ use wasabi::x86::hlt;
 
 #[no_mangle] // Necessary to accurately maintain the name expected by external systems
 fn efi_main(image_handle: EfiHandle, efi_system_table: &EfiSystemTable) {
-    let mut sw = SerialPort::new_for_com1();
-    writeln!(sw, "Hello via serial port").unwrap();
     let mut vram = init_vram(efi_system_table).expect("init_vram failed");
     let vw = vram.width();
     let vh = vram.height();

--- a/wasabi/src/main.rs
+++ b/wasabi/src/main.rs
@@ -8,14 +8,13 @@ use core::writeln;
 use wasabi::graphics::draw_test_pattern;
 use wasabi::graphics::fill_rect;
 use wasabi::graphics::Bitmap;
+use wasabi::init::init_basic_runtime;
 use wasabi::qemu::exit_qemu;
 use wasabi::qemu::QemuExitCode;
-use wasabi::uefi::exit_from_efi_boot_services;
 use wasabi::uefi::init_vram;
 use wasabi::uefi::EfiHandle;
 use wasabi::uefi::EfiMemoryType;
 use wasabi::uefi::EfiSystemTable;
-use wasabi::uefi::MemoryMapHolder;
 use wasabi::uefi::VramTextWriter;
 
 use wasabi::x86::hlt;
@@ -28,14 +27,7 @@ fn efi_main(image_handle: EfiHandle, efi_system_table: &EfiSystemTable) {
     fill_rect(&mut vram, 0x000000, 0, 0, vw, vh).expect("fill_rect failed");
     draw_test_pattern(&mut vram);
     let mut w = VramTextWriter::new(&mut vram);
-    for i in 0..4 {
-        writeln!(w, "i = {i}").unwrap();
-    }
-    let mut memory_map = MemoryMapHolder::new();
-    let status = efi_system_table
-        .boot_services
-        .get_memory_map(&mut memory_map);
-    writeln!(w, "{status:?}").unwrap();
+    let memory_map = init_basic_runtime(image_handle, efi_system_table);
     let mut total_memory_pages = 0;
     for e in memory_map.iter() {
         if e.memory_type() != EfiMemoryType::CONVENTIONAL_MEMORY {

--- a/wasabi/src/qemu.rs
+++ b/wasabi/src/qemu.rs
@@ -1,5 +1,5 @@
 use crate::x86::hlt;
-use crate::x86::write_io_part_u8;
+use crate::x86::write_io_port_u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)] // Do not rely on Rust's default representation; explicitly control it
@@ -9,7 +9,7 @@ pub enum QemuExitCode {
 }
 pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
     // https://github.com/qemu/blob/master/hw/misc/debugexit.c
-    write_io_part_u8(0xf4, exit_code as u8);
+    write_io_port_u8(0xf4, exit_code as u8);
     loop {
         hlt()
     }

--- a/wasabi/src/qemu.rs
+++ b/wasabi/src/qemu.rs
@@ -2,7 +2,7 @@ use crate::x86::hlt;
 use crate::x86::write_io_part_u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u32)]  // Do not rely on Rust's default representation; explicitly control it
+#[repr(u32)] // Do not rely on Rust's default representation; explicitly control it
 pub enum QemuExitCode {
     Success = 0x1, // QEMU will exit with status 3
     Fail = 0x2,    // QEMU will exit will status 5

--- a/wasabi/src/serial.rs
+++ b/wasabi/src/serial.rs
@@ -1,0 +1,60 @@
+use crate::x86::busy_loop_hint;
+use crate::x86::read_io_port_u8;
+use crate::x86::write_io_port_u8;
+use core::fmt;
+
+// c.f. https://wiki.osdev.org/Serial_ports
+
+pub struct SerialPort {
+    base: u16,
+}
+impl SerialPort {
+    pub fn new(base: u16) -> Self {
+        Self { base }
+    }
+    pub fn new_for_com1() -> Self {
+        // Use COM1 at I/O port 0x3f8
+        Self::new(0x3f8)
+    }
+    pub fn init(&mut self) {
+        // Disable all interrupts
+        write_io_port_u8(self.base + 1, 0x00);
+        // Enable DLAB (set baud rate divisor)
+        write_io_port_u8(self.base + 3, 0x80);
+        // baud rate = (115200 / BAUD_DIVISOR)
+        const BAUD_DIVISOR: u16 = 0x0001;
+        write_io_port_u8(self.base, (BAUD_DIVISOR & 0xff) as u8);
+        write_io_port_u8(self.base + 1, (BAUD_DIVISOR >> 8) as u8);
+        // 8 bits, no parity, one stop bit
+        write_io_port_u8(self.base + 3, 0x03);
+        // Enable FIFO, clear them, with 14-byte threshold
+        write_io_port_u8(self.base + 2, 0xC7);
+        // IRQs enabled, RTS/DSR set
+        write_io_port_u8(self.base + 4, 0x0B);
+    }
+    pub fn send_char(&self, c: char) {
+        while (read_io_port_u8(self.base + 5) & 0x20) == 0 {
+            busy_loop_hint();
+        }
+        write_io_port_u8(self.base, c as u8);
+    }
+    pub fn send_str(&self, s: &str) {
+        let mut sc = s.chars();
+        let slen = s.chars().count();
+        for _ in 0..slen {
+            self.send_char(sc.next().unwrap());
+        }
+    }
+}
+impl fmt::Write for SerialPort {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let serial = Self::default();
+        serial.send_str(s);
+        Ok(())
+    }
+}
+impl Default for SerialPort {
+    fn default() -> Self {
+        Self::new_for_com1()
+    }
+}

--- a/wasabi/src/test_runner.rs
+++ b/wasabi/src/test_runner.rs
@@ -1,12 +1,37 @@
 use crate::qemu::exit_qemu;
 use crate::qemu::QemuExitCode;
+use crate::serial::SerialPort;
+use core::any::type_name;
+use core::fmt::Write;
 use core::panic::PanicInfo;
 
-pub fn test_runner(_tests: &[&dyn FnOnce()]) -> ! {
+pub trait Testable {
+    fn run(&self, writer: &mut SerialPort);
+}
+impl<T> Testable for T
+where
+    T: Fn(),
+{
+    fn run(&self, writer: &mut SerialPort) {
+        writeln!(writer, "[RUNNING] >>> {}", type_name::<T>()).unwrap();
+        self();
+        writeln!(writer, "[PASS  ] << {}", type_name::<T>()).unwrap();
+    }
+}
+
+pub fn test_runner(tests: &[&dyn Testable]) -> ! {
+    let mut sw = SerialPort::new_for_com1();
+    writeln!(sw, "Running {} tests...", tests.len()).unwrap();
+    for test in tests {
+        test.run(&mut sw);
+    }
+    writeln!(sw, "Completed {} tests!", tests.len()).unwrap();
     exit_qemu(QemuExitCode::Success)
 }
 
 #[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
+fn panic(info: &PanicInfo) -> ! {
+    let mut sw = SerialPort::new_for_com1();
+    writeln!(sw, "PANIC during test: {info:?}").unwrap();
     exit_qemu(QemuExitCode::Fail);
 }

--- a/wasabi/src/uefi.rs
+++ b/wasabi/src/uefi.rs
@@ -69,6 +69,9 @@ impl EfiMemoryDescriptor {
     pub fn number_of_pages(&self) -> u64 {
         self.number_of_pages
     }
+    pub fn physical_start(&self) -> u64 {
+        self.physical_start
+    }
 }
 
 const MEMORY_MAP_BUFFER_SIZE: usize = 0x8000;

--- a/wasabi/src/x86.rs
+++ b/wasabi/src/x86.rs
@@ -4,6 +4,20 @@ pub fn hlt() {
     unsafe { asm!("hlt") }
 }
 
-pub fn write_io_part_u8(port: i16, data: u8) {
+pub fn busy_loop_hint() {
+    unsafe { asm!("pause") }
+}
+
+pub fn read_io_port_u8(port: u16) -> u8 {
+    let mut data: u8;
+    unsafe {
+        asm!("in al, dx",
+        out("al") data,
+            in("dx") port)
+    }
+    data
+}
+
+pub fn write_io_port_u8(port: u16, data: u8) {
     unsafe { asm!("out dx, al", in("al") data, in("dx") port) } // no OS, so need to communicate directly with the hardware
 }


### PR DESCRIPTION
## why
`#[no_std]`のベアメタル環境（OS無し）なので、`std::alloc`がない
なので`let v = Vec::new();` のようなBox, Vec, Stringが書き方は使えない

複数回割り当てたときのイメージ↓
```bash
  Initial:
  |---------- Free (256B) ----------|
  0x1000                      0x1100

  1st alloc (32B):
  |-------- Free (192B) ------|H|32B|
  0x1000                0x10C0  0x1100

  2nd alloc (64B):
  |---- Free (96B) ----|H|64B|H|32B|
  0x1000          0x1060  0x10C0  0x1100
                  ↑
              次はここから割り当て
```

## note
- Headerを32byteの2の累乗サイズに設定してアラインメントを簡素化
- メモリ末尾から割り当て  
- Dropでpanic発生させる
  Headerはメモリ管理のメタデータ。DropするとメモリリークするためNG